### PR TITLE
Drop the origin/main branch reference

### DIFF
--- a/.github/workflows/ilk.yml
+++ b/.github/workflows/ilk.yml
@@ -9,7 +9,7 @@ name: ilk
 
 on:
   push:
-    branches: [main, master, origin/main]
+    branches: [main, master]
   pull_request:
 
 jobs:


### PR DESCRIPTION
The `origin/main` branch was a duplicate of `main` that had become GitHub's default. With the default switched to `main`, `main` fast-forwarded to the merged work, and the duplicate branch deleted, the workflow no longer needs to watch for it.

Leaves one remote branch and one local branch, and removes the "ambiguous refname" warnings git had been emitting on every command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SmMWhvZNXMAdbVsygRNBnF