### PR TITLE
Queue the next layers, behind check assertions

### DIFF
--- a/docs/plans/PLAN-layer-queue.md
+++ b/docs/plans/PLAN-layer-queue.md
@@ -1,0 +1,133 @@
+---
+id: plan-layer-queue
+title: Layer queue
+status: active
+updated: 2026-08-07
+---
+
+# Layer queue
+
+What gets built next, in order, and why that order. Shapes live in
+[layers/README.md](../../layers/README.md); this document is only the sequencing and
+the reasoning behind it.
+
+## Outcome
+
+Every layer ilk publishes proves its own checks catch what it claims, and the four
+backlog items currently blocked on core decisions are unblocked by making those
+decisions rather than by working around them.
+
+## The finding this queue answers
+
+Twelve layers ship today. Nine enforce something, two enforce nothing, one runs
+only what the repository hands it. That distribution is fine.
+
+What is not fine: **ten of the twelve have no test that their checks fire.**
+`ilk layer test` proves exactly one property — add is idempotent and rm restores
+the repository — and CI runs it against all twelve. It never asserts that a check
+rejects anything. Only `toolkit` and `gh-projects` ship a `test/run.sh`, and both
+of those test provider scripts rather than checks.
+
+The checks sit on top of Go builtins that *are* tested (`internal/checks` has real
+coverage), so they probably work. But "the builtin is tested" and "this layer
+wired it up correctly" are different claims, and only the first has evidence. A
+layer whose check silently matches nothing looks exactly like a layer whose check
+passes — the same failure mode `record.coverage` exists to catch in documents, and
+ilk does not currently apply it to itself.
+
+Every layer added before that is fixed multiplies unverified surface. Every layer
+added after ships with evidence. That is the whole argument for the order below.
+
+## Order
+
+### 0 — Check assertions in `ilk layer test` · next
+
+Extend the layer test harness so a layer can assert its checks reject what they
+are supposed to reject, then backfill the ten layers that have none.
+
+The sandbox already exists — `ilk layer test` builds a throwaway repository, adds
+the layer, applies twice and removes it. The missing piece is planting a fixture
+that violates a check and asserting the check fails:
+
+```yaml
+# layers/blueprint/test/checks.yaml
+- check: blueprint.epic
+  fixture: spec-with-missing-epic/
+  expect: fail
+- check: blueprint.epic
+  fixture: spec-with-real-epic/
+  expect: pass
+```
+
+Both directions matter. A check that fails on everything is as broken as one that
+fails on nothing, and only the second is currently possible to notice.
+
+*Accepted when:* CI fails if a layer's check stops rejecting its own fixture, and
+every layer that registers a check has at least one failing and one passing case.
+
+### 1 — The credential story · unblocks two layers
+
+Where a provider token comes from, and what the failure looks like when it is
+absent. It must come from the environment, never the repository, and an absent
+credential must say so rather than looking like an empty diff or a clean preview.
+
+`gh-projects` sidestepped this by leaning on `gh` being already authenticated.
+`pulumi` and `linear-mirror` cannot.
+
+*Accepted when:* a layer requiring a credential skips its check with a reason
+`ilk doctor` can print, and never reports success on a credential it did not have.
+
+### 2 — The `mcp:` neutral artifact · unblocks two more
+
+Add `mcp:` alongside `instructions:`, `skills:` and `hooks:` in the manifest, and
+teach each target to render it. Roughly 150 lines of core plus per-target
+rendering. This is the last artifact type where a layer would otherwise have to
+ship one agent's literal file, which is the thing ilk exists not to do.
+
+*Accepted when:* a layer declares an MCP server once and `.mcp.json` and
+`.cursor/mcp.json` are both projections of it.
+
+### 3 — Layers, in this order
+
+| Layer | Why here |
+|---|---|
+| `pr-prep` | Smallest unblocked item, immediate value, no dependencies |
+| `autoresearch` | Unblocked; the only layer measuring staleness by expiry rather than coupling |
+| `deprecation` | Same mechanic as staleness-by-coupling, applied to removal dates |
+| `secrets` | Highest-consequence agent failure; wraps an existing scanner |
+| `pulumi` | After the credential story |
+| `migrations` | After `secrets`, which establishes the wrap-a-tool-via-capability shape |
+| `codegraph` | After `mcp:`, for the version worth having |
+| `linear-mirror` | After the credential story |
+| `release-notes` | After `pr-prep`, which it shares its derive-from-the-record idea with |
+| `html-wireframe` | Pairs with `visual-qa`; lower value than the above |
+| `incident` | Only meaningful for a project with production |
+
+## Boundaries
+
+Not in this queue, and each for a stated reason:
+
+- **`brainstorm`** — argued out of existing. A check counting alternatives is
+  cheapest to satisfy by writing strawmen, and the durable artifact already exists
+  as a decision naming what it rejected.
+- **`kanban`** — a competing planning model rather than an addition. Worth building
+  only as a view over `blueprint`, owning no state.
+- **`llm-wiki`** — overlaps `codegraph` and the record. Revisit once `codegraph`
+  exists, since the interesting version is the synthesis over the index.
+- **`pm-loops`** — shipped as `plan-hygiene`, with the scheduling half deliberately
+  dropped.
+
+## Open questions
+
+1. **Should check assertions be mandatory?** CI could fail any layer in this
+   repository that registers a check without a fixture. That is the right standard
+   here; whether to hold *published* layers to it is a question about how much
+   friction the ecosystem will bear before people stop publishing.
+2. **Does `secrets` belong in ilk at all?** It wraps a scanner, and a repository
+   could wire that scanner into `gates` directly with no layer. The layer earns its
+   place only if it adds the pre-commit discipline and the "what to do when one
+   leaks" skill, not merely the check.
+3. **Is `migrations` too stack-specific?** The hash-an-applied-migration rule is
+   general; where migrations live and what "applied" means is not. It may need a
+   capability supplying the migrations directory and the applied-set, which is a
+   larger surface than any current layer requires.

--- a/docs/plans/PLAN-roadmap.md
+++ b/docs/plans/PLAN-roadmap.md
@@ -106,8 +106,13 @@ Remaining:
   `gh-projects` proves it, but it leans on `gh` for authentication. A provider with its
   own API token — Linear, Jira — needs a decided answer for where the token comes from
   and what the failure looks like when it is absent.
-- More layers: `pr-prep`, `codegraph`, `pulumi`, `autoresearch`, `html-wireframe`,
-  `incident`. The backlog with decided shapes is in
+- **Check assertions in `ilk layer test`.** It proves add/rm reversibility and
+  nothing about enforcement, so ten of twelve layers have no evidence their checks
+  reject anything. This is the next piece of work; see
+  [PLAN-layer-queue](PLAN-layer-queue.md).
+- More layers: `pr-prep`, `codegraph`, `pulumi`, `autoresearch`, `deprecation`,
+  `secrets`, `migrations`, `release-notes`, `html-wireframe`, `incident`, in the
+  order set out in [PLAN-layer-queue](PLAN-layer-queue.md). The backlog with decided shapes is in
   [layers/README.md](../../layers/README.md). `pulumi` is the first tenant of the `infra`
   group and shares `linear-mirror`'s credential blocker; `brainstorm` was specified and
   then argued out of existing, on the grounds that a check counting alternatives is

--- a/layers/README.md
+++ b/layers/README.md
@@ -88,6 +88,89 @@ there. A layer its adopters cannot improve decays, and that is too easy to not n
 These are specified rather than vague — each has a decided shape, and what is missing is
 the work, not the design. Contributions welcome; so is disagreement with the shape.
 
+The order these get built in is
+[docs/plans/PLAN-layer-queue.md](../docs/plans/PLAN-layer-queue.md), along with the
+reason nothing here is next until `ilk layer test` can assert a check rejects
+something.
+
+### `deprecation` — a removal date the code is held to
+
+`DEPRECATED-*.md` in the record, carrying a `remove_after:` date and the `covers:`
+paths the deprecation applies to. The check fails once that date has passed and the
+covered paths still exist.
+
+**Decided.** This is staleness-by-coupling pointed at removal instead of review, and
+it reuses the same machinery: a document declares what it is about, and git says
+whether that subject is still there. A deprecation nobody removes is the most common
+way a codebase accumulates two ways to do everything, and the usual reminder — a
+comment saying "remove after v3" — is invisible to everything that could act on it.
+
+**Checks:** every `DEPRECATED-` document has a `remove_after:` and a non-empty
+`covers:`; nothing is past its date while its covered paths still match; a
+deprecation whose paths already match nothing is reported as done rather than
+lingering.
+
+**The open question** is what happens on the day it fires. Failing `ilk check` is
+right, but a deprecation that becomes urgent on a date nobody chose deliberately
+will get exempted rather than actioned. It may need the same baseline mechanism the
+record layer uses, so an extension is a visible decision rather than a silent one.
+
+### `secrets` — wrap a scanner, do not write one
+
+**Decided: wrap, do not build.** The same call `codegraph` made. Detection is a
+solved problem with well-maintained tools; what is missing is the discipline around
+it. A capability, `secrets.command`, supplies the scanner — gitleaks, trufflehog,
+whatever the project already uses — and the layer supplies the pre-commit hook, the
+CI gate, and the part nobody writes down: what to do once one has leaked.
+
+**Checks:** the scanner is clean. That is the whole check, and it is deliberately
+thin, because the layer's value is the hook plus the skill rather than the
+detection.
+
+**The skill is the point.** An agent that finds a committed credential will
+reliably do the wrong thing — remove it in a new commit and report it fixed, which
+leaves it in the history and in every clone. The skill says: rotate first, because
+the credential is compromised the moment it is pushed and rewriting history does not
+un-compromise it; then purge; then rotate again if the purge was slow.
+
+**Rated highest-consequence** of anything on this list. An agent committing a key is
+the failure mode with the largest blast radius and the shortest path to happening.
+
+### `migrations` — an applied migration is immutable
+
+Hash every migration ilk has seen applied, and fail when one of them changes. Require
+either a down migration or an explicit, written statement that this one is
+irreversible.
+
+**Decided.** Editing an already-applied migration is the kind of mistake that works
+perfectly on the machine that made it and corrupts every other environment, which is
+exactly the shape of error an agent makes and no test catches.
+
+**Blocked on a question rather than on work.** The immutability rule is universal;
+where migrations live and what "applied" means is not. It likely needs a capability
+supplying both the directory and the applied set, which is a wider interface than any
+current layer asks for. Worth settling before writing it, because a layer that only
+fits one ORM is a layer that should have been a script.
+
+**First consumer** would be a drizzle project, which is a reasonable place to find out
+whether the interface generalises.
+
+### `release-notes` — assembled from the record, not from memory
+
+Derive a changelog from `docs/log/` entries and the plans marked accepted since the
+last release, rather than having somebody reconstruct it from commit messages.
+
+**Decided.** The record already holds what happened and what was accepted; a release
+note written by hand is that same information typed a second time, less accurately.
+Pairs with `pr-prep`, which does the same derivation one scope down.
+
+**Shape:** a command that assembles the notes for a version range, a check that a
+tagged release has notes, and a convention for the one thing derivation cannot supply
+— which changes a reader actually needs to act on.
+
+**Not before `pr-prep`**, which is smaller and establishes whether deriving prose
+from the record produces something anybody wants to read.
+
 ### `pulumi` — the first layer in the `infra` group
 
 Infrastructure as code, with the one discipline that matters when an agent is holding


### PR DESCRIPTION
Records what gets built next and why in that order, after auditing what the twelve shipped layers actually enforce.

## The audit

| | Layers |
|---|---|
| Enforce something | record (6 checks), maintainer (5), blueprint (4), plan-hygiene (3), ask-human (2), visual-qa (2), archive (1), gh-projects (1) |
| Enforce nothing | toolkit (by design — it is documentation), **dev-loops** |
| Runs only what you hand it | gates — all three checks delegate to repository capabilities |

Thin but not empty: `compound-lessons` requires an `encoded_as:` key to be *present*, not that it names a real change — `encoded_as: we will be more careful` passes, which is the failure its own README says it prevents. `visual-qa` verifies referenced screenshots exist, not that they show anything.

## The finding the queue answers

**Ten of twelve layers have no test that their checks fire.** `ilk layer test` proves exactly one property — add is idempotent, rm restores the repository — and CI runs it against all twelve. It never asserts a check rejects anything. Only `toolkit` and `gh-projects` ship a `test/run.sh`, and both test provider scripts rather than checks.

The checks sit on tested Go builtins, so they probably work. But "the builtin is tested" and "this layer wired it up correctly" are different claims, and only the first has evidence. A check whose glob matches nothing looks identical to one that passes — the same failure `record.coverage` exists to catch in documents, not applied to ilk itself.

## Order

0. **Check assertions in `ilk layer test`** — fixture in, expected verdict out, both directions. Then backfill the ten.
1. **The credential story** — unblocks `pulumi` and `linear-mirror`.
2. **The `mcp:` artifact type** — unblocks `mcp-servers`, improves `codegraph`.
3. **Layers**, starting with `pr-prep`.

## Four added to the backlog

- **`deprecation`** — staleness-by-coupling pointed at removal dates rather than review.
- **`secrets`** — wraps a scanner via a capability; the content is the skill saying rotate *before* purging, because an agent that finds a leaked key will remove it in a new commit and call it fixed.
- **`migrations`** — an applied migration is immutable. Blocked on a question, not work: what "applied" means without being ORM-specific.
- **`release-notes`** — derived from `docs/log/` and accepted plans, after `pr-prep` proves the idea.

No code changes. `ilk check`: 18 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SmMWhvZNXMAdbVsygRNBnF